### PR TITLE
Validate request attributes

### DIFF
--- a/src/Constraint/RequestConstraint.php
+++ b/src/Constraint/RequestConstraint.php
@@ -31,21 +31,25 @@ class RequestConstraint extends Constraint
     /** @var Constraint|Constraint[]|null */
     public $request;
 
+    /** @var Constraint|Constraint[]|null */
+    public $attributes;
+
     /**
-     * @param array{query?: Constraint|Constraint[], request?: Constraint|Constraint[]}|null $options
+     * @param array{query?: Constraint|Constraint[], request?: Constraint|Constraint[], attributes?: Constraint|Constraint[]}|null $options
      */
     public function __construct($options = null)
     {
         // make sure defaults are set
-        $options            = $options ?? [];
-        $options['query']   = $options['query'] ?? null;
-        $options['request'] = $options['request'] ?? null;
+        $options               = $options ?? [];
+        $options['query']      = $options['query'] ?? null;
+        $options['request']    = $options['request'] ?? null;
+        $options['attributes'] = $options['attributes'] ?? null;
 
         parent::__construct($options);
     }
 
     public function getRequiredOptions(): array
     {
-        return ['query', 'request'];
+        return ['query', 'request', 'attributes'];
     }
 }

--- a/src/Constraint/RequestConstraintFactory.php
+++ b/src/Constraint/RequestConstraintFactory.php
@@ -22,15 +22,9 @@ class RequestConstraintFactory
      */
     public function createConstraint(ValidationRules $validationRules): RequestConstraint
     {
-        $options            = [];
-        $queryDefinitions   = $validationRules->getQueryRules();
-        $requestDefinitions = $validationRules->getRequestRules();
-
-        if ($queryDefinitions !== null) {
-            $options['query'] = $this->factory->fromRuleDefinitions($queryDefinitions);
-        }
-        if ($requestDefinitions !== null) {
-            $options['request'] = $this->factory->fromRuleDefinitions($requestDefinitions);
+        $options = [];
+        foreach ($validationRules->getDefinitions() as $key => $definitions) {
+            $options[$key] = $this->factory->fromRuleDefinitions($definitions);
         }
 
         return new RequestConstraint($options);

--- a/src/Constraint/RequestConstraintValidator.php
+++ b/src/Constraint/RequestConstraintValidator.php
@@ -51,5 +51,12 @@ class RequestConstraintValidator extends ConstraintValidator
                 ->setCode($constraint::MISSING_REQUEST_CONSTRAINT)
                 ->addViolation();
         }
+
+        if ($constraint->attributes !== null) {
+            $context->getValidator()
+                ->inContext($context)
+                ->atPath('[attributes]')
+                ->validate($value->attributes->all(), $constraint->attributes);
+        }
     }
 }

--- a/src/ValidationRules.php
+++ b/src/ValidationRules.php
@@ -4,46 +4,44 @@ declare(strict_types=1);
 namespace DigitalRevolution\SymfonyRequestValidation;
 
 use InvalidArgumentException;
-use Symfony\Component\Validator\Constraint;
 
 class ValidationRules
 {
-    /** @var Constraint|array<string, string|Constraint|array<string|Constraint>>|null */
-    private $queryRules;
-
-    /** @var Constraint|array<string, string|Constraint|array<string|Constraint>>|null */
-    private $requestRules;
+    /**
+     * @var array{
+     *          query?:      Constraint|array<string, string|Constraint|array<string|Constraint>>,
+     *          request?:    Constraint|array<string, string|Constraint|array<string|Constraint>>,
+     *          attributes?: Constraint|array<string, string|Constraint|array<string|Constraint>>
+     * } $definitions
+     */
+    private $definitions;
 
     /**
      * @param array{
-     *          query?:   Constraint|array<string, string|Constraint|array<string|Constraint>>,
-     *          request?: Constraint|array<string, string|Constraint|array<string|Constraint>>
-     *        } $definitions
+     *          query?:      Constraint|array<string, string|Constraint|array<string|Constraint>>,
+     *          request?:    Constraint|array<string, string|Constraint|array<string|Constraint>>,
+     *          attributes?: Constraint|array<string, string|Constraint|array<string|Constraint>>
+     *          } $definitions
      */
     public function __construct(array $definitions)
     {
         // expect no other keys than `query` or `request`
-        if (count(array_diff(array_keys($definitions), ['query', 'request'])) > 0) {
-            throw new InvalidArgumentException('Expecting at most `query` or `request` property to be set');
+        if (count(array_diff(array_keys($definitions), ['query', 'request', 'attributes'])) > 0) {
+            throw new InvalidArgumentException('Expecting at most `query`, `request` or `attribute` property to be set');
         }
 
-        $this->queryRules   = $definitions['query'] ?? null;
-        $this->requestRules = $definitions['request'] ?? null;
+        $this->definitions = $definitions;
     }
 
     /**
-     * @return Constraint|array<string, string|Constraint|array<string|Constraint>>|null
+     * @return array{
+     *          query?:      Constraint|array<string, string|Constraint|array<string|Constraint>>,
+     *          request?:    Constraint|array<string, string|Constraint|array<string|Constraint>>,
+     *          attributes?: Constraint|array<string, string|Constraint|array<string|Constraint>>
+     * } $definitions
      */
-    public function getQueryRules()
+    public function getDefinitions(): array
     {
-        return $this->queryRules;
-    }
-
-    /**
-     * @return Constraint|array<string, string|Constraint|array<string|Constraint>>|null
-     */
-    public function getRequestRules()
-    {
-        return $this->requestRules;
+        return $this->definitions;
     }
 }

--- a/src/ValidationRules.php
+++ b/src/ValidationRules.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace DigitalRevolution\SymfonyRequestValidation;
 
 use InvalidArgumentException;
+use Symfony\Component\Validator\Constraint;
 
 class ValidationRules
 {

--- a/tests/DataProvider/Constraint/RequestConstraintValidatorDataProvider.php
+++ b/tests/DataProvider/Constraint/RequestConstraintValidatorDataProvider.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\SymfonyRequestValidation\Tests\DataProvider\Constraint;
+
+class RequestConstraintValidatorDataProvider
+{
+    /**
+     * @return array<string, array<array, bool>>
+     */
+    public static function dataProvider(): array
+    {
+        return [
+            'success' => [['email' => 'example@example.com'], true],
+            'failure' => [['email' => 'unit test'], false]
+        ];
+    }
+}

--- a/tests/Integration/AbstractValidatedRequestTest.php
+++ b/tests/Integration/AbstractValidatedRequestTest.php
@@ -72,6 +72,32 @@ class AbstractValidatedRequestTest extends TestCase
         static::assertTrue($request->isValid());
     }
 
+    /**
+     * @dataProvider dataProvider
+     * @param array<string, mixed> $data
+     * @param Collection|array<string, string|Constraint|array<string|Constraint>>|null $rules
+     * @throws InvalidRequestException|InvalidRuleException
+     */
+    public function testRequestAttributesValidation(array $data, $rules, bool $isValid): void
+    {
+        $request = new Request([], [], $data);
+        $stack   = new RequestStack();
+        $stack->push($request);
+
+        $validator       = Validation::createValidator();
+        $validationRules = new ValidationRules(['attributes' => $rules]);
+
+        // expect exception
+        if ($isValid === false) {
+            $this->expectException(InvalidRequestException::class);
+            new MockValidatedRequest($stack, $validator, $validationRules);
+        }
+
+        // expect success
+        $request = new MockValidatedRequest($stack, $validator, $validationRules);
+        static::assertTrue($request->isValid());
+    }
+
 
     public function dataProvider(): Generator
     {

--- a/tests/Unit/Constraint/RequestConstraintTest.php
+++ b/tests/Unit/Constraint/RequestConstraintTest.php
@@ -51,6 +51,6 @@ class RequestConstraintTest extends TestCase
     public function testGetRequiredOptions(): void
     {
         $constraint = new RequestConstraint();
-        static::assertSame(['query', 'request'], $constraint->getRequiredOptions());
+        static::assertSame(['query', 'request', 'attributes'], $constraint->getRequiredOptions());
     }
 }

--- a/tests/Unit/Constraint/RequestConstraintValidatorTest.php
+++ b/tests/Unit/Constraint/RequestConstraintValidatorTest.php
@@ -73,21 +73,37 @@ class RequestConstraintValidatorTest extends TestCase
         static::assertCount($success ? 0 : 1, $this->context->getViolations());
     }
 
+
     /**
      * @param array<mixed> $data
      * @dataProvider dataProvider
      * @covers ::validate
      */
-    public function testValidateQueryAndRequest(array $data, bool $success): void
+    public function testValidateAttributes(array $data, bool $success): void
     {
-        $request    = new Request($data, $data);
+        $request    = new Request([], [], $data);
+        $constraint = new RequestConstraint(['attributes' => new Assert\Collection(['email' => new Assert\Required(new Assert\Email())])]);
+        $this->context->setConstraint($constraint);
+        $this->validator->validate($request, $constraint);
+        static::assertCount($success ? 0 : 1, $this->context->getViolations());
+    }
+
+    /**
+     * @param array<mixed> $data
+     * @dataProvider dataProvider
+     * @covers ::validate
+     */
+    public function testValidateQueryRequestAttributes(array $data, bool $success): void
+    {
+        $request    = new Request($data, $data, $data);
         $constraint = new RequestConstraint([
-            'query'   => new Assert\Collection(['email' => new Assert\Required(new Assert\Email())]),
-            'request' => new Assert\Collection(['email' => new Assert\Required(new Assert\Email())])
+            'query'      => new Assert\Collection(['email' => new Assert\Required(new Assert\Email())]),
+            'request'    => new Assert\Collection(['email' => new Assert\Required(new Assert\Email())]),
+            'attributes' => new Assert\Collection(['email' => new Assert\Required(new Assert\Email())])
         ]);
         $this->context->setConstraint($constraint);
         $this->validator->validate($request, $constraint);
-        static::assertCount($success ? 0 : 2, $this->context->getViolations());
+        static::assertCount($success ? 0 : 3, $this->context->getViolations());
     }
 
     /**

--- a/tests/Unit/Constraint/RequestConstraintValidatorTest.php
+++ b/tests/Unit/Constraint/RequestConstraintValidatorTest.php
@@ -47,7 +47,7 @@ class RequestConstraintValidatorTest extends TestCase
 
     /**
      * @param array<mixed> $data
-     * @dataProvider dataProvider
+     * @dataProvider \DigitalRevolution\SymfonyRequestValidation\Tests\DataProvider\Constraint\RequestConstraintValidatorDataProvider::dataProvider
      * @covers ::validate
      */
     public function testValidateQuery(array $data, bool $success): void
@@ -61,7 +61,7 @@ class RequestConstraintValidatorTest extends TestCase
 
     /**
      * @param array<mixed> $data
-     * @dataProvider dataProvider
+     * @dataProvider \DigitalRevolution\SymfonyRequestValidation\Tests\DataProvider\Constraint\RequestConstraintValidatorDataProvider::dataProvider
      * @covers ::validate
      */
     public function testValidateRequest(array $data, bool $success): void
@@ -76,7 +76,7 @@ class RequestConstraintValidatorTest extends TestCase
 
     /**
      * @param array<mixed> $data
-     * @dataProvider dataProvider
+     * @dataProvider \DigitalRevolution\SymfonyRequestValidation\Tests\DataProvider\Constraint\RequestConstraintValidatorDataProvider::dataProvider
      * @covers ::validate
      */
     public function testValidateAttributes(array $data, bool $success): void
@@ -90,7 +90,7 @@ class RequestConstraintValidatorTest extends TestCase
 
     /**
      * @param array<mixed> $data
-     * @dataProvider dataProvider
+     * @dataProvider \DigitalRevolution\SymfonyRequestValidation\Tests\DataProvider\Constraint\RequestConstraintValidatorDataProvider::dataProvider
      * @covers ::validate
      */
     public function testValidateQueryRequestAttributes(array $data, bool $success): void
@@ -104,17 +104,6 @@ class RequestConstraintValidatorTest extends TestCase
         $this->context->setConstraint($constraint);
         $this->validator->validate($request, $constraint);
         static::assertCount($success ? 0 : 3, $this->context->getViolations());
-    }
-
-    /**
-     * @return array<string, array<array, bool>>
-     */
-    public function dataProvider(): array
-    {
-        return [
-            'success' => [['email' => 'example@example.com'], true],
-            'failure' => [['email' => 'unit test'], false]
-        ];
     }
 
     /**

--- a/tests/Unit/ValidationRulesTest.php
+++ b/tests/Unit/ValidationRulesTest.php
@@ -7,7 +7,6 @@ use DigitalRevolution\SymfonyRequestValidation\ValidationRules;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\NotBlank;
-use Symfony\Component\Validator\Constraints\NotNull;
 
 /**
  * @coversDefaultClass \DigitalRevolution\SymfonyRequestValidation\ValidationRules
@@ -16,20 +15,13 @@ class ValidationRulesTest extends TestCase
 {
     /**
      * @covers ::__construct
-     * @covers ::getQueryRules
-     * @covers ::getRequestRules
+     * @covers ::getDefinitions
      */
     public function testConstructorAndGetters(): void
     {
-        $constraintA = new NotBlank();
-        $constraintB = new NotNull();
-        $rules       = new ValidationRules(['query' => $constraintA]);
-        static::assertSame($constraintA, $rules->getQueryRules());
-        static::assertNull($rules->getRequestRules());
-
-        $rules = new ValidationRules(['query' => $constraintA, 'request' => $constraintB]);
-        static::assertSame($constraintA, $rules->getQueryRules());
-        static::assertSame($constraintB, $rules->getRequestRules());
+        $definitions = ['query' => new NotBlank()];
+        $rules       = new ValidationRules($definitions);
+        static::assertSame($definitions, $rules->getDefinitions());
     }
 
     /**


### PR DESCRIPTION
Next to 'query' and 'request' data properties, also optionally allow validation of 'attributes' of the request.